### PR TITLE
Update underlying dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.12.4</version>
+                    <version>2.19.1</version>
                     <!-- Standard classloader, results to console -->
                     <configuration>
                         <childDelegation>false</childDelegation>
@@ -98,7 +98,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>2.8</version>
+				<version>2.17</version>
 				<configuration>
 					<configLocation>checkstyle-config.xml</configLocation>
 				</configuration>
@@ -110,13 +110,18 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.0.1</version>
+			<version>3.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+ 			<groupId>org.apache.maven</groupId>
+ 			<artifactId>maven-artifact</artifactId>
+ 			<version>3.0.3</version>
+ 		</dependency>
+		<dependency>
 			<groupId>org.im4java</groupId>
 			<artifactId>im4java</artifactId>
-			<version>1.2.0</version>
+			<version>1.4.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -127,38 +132,38 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.8.2</version>
+			<version>4.12</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-all</artifactId>
-			<version>1.8.5</version>
+			<version>1.10.19</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-module-junit4</artifactId>
-			<version>1.4.12</version>
+			<version>1.6.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-api-mockito</artifactId>
-			<version>1.4.12</version>
+			<version>1.6.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-all</artifactId>
-			<version>1.1</version>
+			<version>1.3</version>
 			<type>jar</type>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.findbugs</groupId>
 			<artifactId>annotations</artifactId>
-			<version>2.0.0</version>
+			<version>3.0.1u2</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,16 +16,8 @@
 	<name>gm4java</name>
 	<url>http://kennethxu.blogspot.com/2013/03/integrate-java-and-graphicsmagick.html</url>
 
-		<properties>
+	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<commons.lang3.version>3.0.1</commons.lang3.version>
-		<!-- the latest version for im4java is 1.3.1. But it is not in a maven 
-			repo. We will have to request RE to upload it. -->
-		<im4java.version>1.2.0</im4java.version>
-		<hamcrest.version>1.1</hamcrest.version>
-		<junit.version>4.8.2</junit.version>
-		<powermock.version>1.4.12</powermock.version>
-		<commons.io.version>1.3.2</commons.io.version>
 	</properties>
 	<description>GraphicsMagick interactive mode Java integration</description>
     <licenses>
@@ -118,13 +110,13 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>${commons.lang3.version}</version>
+			<version>3.0.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.im4java</groupId>
 			<artifactId>im4java</artifactId>
-			<version>${im4java.version}</version>
+			<version>1.2.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -135,7 +127,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>${junit.version}</version>
+			<version>4.8.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -147,19 +139,19 @@
 		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-module-junit4</artifactId>
-			<version>${powermock.version}</version>
+			<version>1.4.12</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-api-mockito</artifactId>
-			<version>${powermock.version}</version>
+			<version>1.4.12</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-all</artifactId>
-			<version>${hamcrest.version}</version>
+			<version>1.1</version>
 			<type>jar</type>
 			<scope>test</scope>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -125,9 +125,9 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-		    <groupId>commons-pool</groupId>
-		    <artifactId>commons-pool</artifactId>
-		    <version>1.6</version>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-pool2</artifactId>
+			<version>2.4.2</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/main/java/org/gm4java/engine/support/Constants.java
+++ b/src/main/java/org/gm4java/engine/support/Constants.java
@@ -43,7 +43,6 @@ final class Constants {
         "-fail", GM_FAIL,
         "-prompt", "off",
         "-echo", "off",
-        "-safe-mode", "on",
         "-"
     };
     // @formatter:on

--- a/src/main/java/org/gm4java/engine/support/WhenExhaustedAction.java
+++ b/src/main/java/org/gm4java/engine/support/WhenExhaustedAction.java
@@ -1,7 +1,5 @@
 package org.gm4java.engine.support;
 
-import org.apache.commons.pool.impl.GenericObjectPool;
-
 /**
  * Defines the behavior of the {@link PooledGMService#getConnection()} method when the pool is exhausted.
  * 
@@ -11,38 +9,17 @@ public enum WhenExhaustedAction {
     /**
      * Throw a {@link NoSuchElementException}.
      */
-    FAIL(GenericObjectPool.WHEN_EXHAUSTED_FAIL),
+    FAIL,
 
-    /**
-     * Blocks until a new or idle connection is available. Or fail if maxWait is positive and passed.
-     */
-    BLOCK(GenericObjectPool.WHEN_EXHAUSTED_BLOCK),
+	/**
+	 * Blocks until a new or idle connection is available, waiting up to
+	 * <code>maxWait</code> milliseconds. If <code>maxWait</code> is negative,
+	 * then {@link PooledGMService#getConnection()} blocks indefinitely.
+	 */
+    BLOCK,
 
     /**
      * Create a new connection and return it (essentially making maxActive meaningless).
      */
-    GROW(GenericObjectPool.WHEN_EXHAUSTED_GROW);
-
-    private WhenExhaustedAction(byte whenExhaustedAction) {
-        this.whenExhaustedAction = whenExhaustedAction;
-    }
-
-    private final byte whenExhaustedAction;
-
-    byte toValue() {
-        return whenExhaustedAction;
-    }
-
-    static WhenExhaustedAction fromValue(byte whenExhaustedAction) {
-        switch (whenExhaustedAction) {
-        case GenericObjectPool.WHEN_EXHAUSTED_BLOCK:
-            return WhenExhaustedAction.BLOCK;
-        case GenericObjectPool.WHEN_EXHAUSTED_FAIL:
-            return WhenExhaustedAction.FAIL;
-        case GenericObjectPool.WHEN_EXHAUSTED_GROW:
-            return WhenExhaustedAction.GROW;
-        default:
-            throw new IllegalArgumentException("whenExhaustedAction " + whenExhaustedAction + " not recognized.");
-        }
-    }
+    GROW;
 }


### PR DESCRIPTION
The goal of this PR is to update this project's dependencies to their latest stable versions. For almost all of dependencies, this was simply a matter of updating their version in pom.xml (see ebe612a).

GraphicsMagick 1.3.22 removed the -safe-mode argument for the batch command. For compatibility with the newer versions, this argument is no longer being used when spawning new GM processes (see 7d84721). This change has been discussed thoroughly (#14 #9 and #10). Although this approach of removing the argument appears over-simplified, I believe it's the best choice. It keeps the codebase small and intuitive while minimally interfering with library users. 

Additionally, the commons-pool library has been upgraded to a new major version (2.4.2). From that project's homepage:

> Version 2 of Apache Commons Pool contains a completely re-written pooling implementation compared to the 1.x series. In addition to performance and scalability improvements, version 2 includes robust instance tracking and pool monitoring.

Upgrading to this later version required some underlying code changes, but the user-facing API is the same.

Overall, this PR should introduce little to no compatibility issues. All unit tests pass. Please let me know if there's anything you'd like to discuss further. 
